### PR TITLE
Migrate from `cfx` to `jpm` (and `jpm-mobile`).

### DIFF
--- a/src/firefox/data/js/browser.js
+++ b/src/firefox/data/js/browser.js
@@ -40,7 +40,7 @@ Browser._main_script = function() {
 	var data = require("sdk/self").data;
 
 	// make resource://location-guard/... likes to point to our data dir
-	require('resource').set('location-guard', data.url(''));
+	require('./resource').set('location-guard', data.url(''));
 
 	// refresh icon when a tab is activated
 	//
@@ -415,10 +415,9 @@ Browser.gui._refreshPageAction = function(info) {
 
 	} else if(info.hidden) {
 		// if the API is called by the icon is hidden, add menu
-		//
 		this._menu = nw.menu.add({
 			name: "Location Guard",
-			callback: require('PopupFennec').show
+			callback: require('../../lib/PopupFennec').show
 		});
 
 	} else {
@@ -432,7 +431,7 @@ Browser.gui._refreshPageAction = function(info) {
 		this._pageaction = PageActions.add({
 			icon: "data:image/png;base64," + this._base64_cache[icon],
 			title: "Location Guard",
-			clickCallback: require('PopupFennec').show
+			clickCallback: require('../../lib/PopupFennec').show
 		});
 	}
 
@@ -440,7 +439,7 @@ Browser.gui._refreshPageAction = function(info) {
 	nw.toast.show("Location Guard is enabled", "long", {
 		button: {
 			label: "SHOW",
-			callback: require('PopupFennec').show
+			callback: require('../../lib/PopupFennec').show
 		}
 	});
 	*/

--- a/src/firefox/lib/PopupFennec.js
+++ b/src/firefox/lib/PopupFennec.js
@@ -7,7 +7,7 @@ let Cu = require("chrome").Cu;
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/Prompt.jsm");
 
-let { Browser, Util } = require('main');
+let { Browser, Util } = require('./main');
 
 let PopupFennec = exports;
 

--- a/src/firefox/package.json
+++ b/src/firefox/package.json
@@ -1,7 +1,8 @@
 {
   "name": "location-guard",
   "fullName": "Location Guard",
-  "id": "jid1-HdwPLukcGQeOSh",
+  "id": "jid1-HdwPLukcGQeOSh@jetpack",
+  "main": "lib/main.js",
   "description": "Hide your geographic location from websites.",
   "author": "Konstantinos Chatzikokolakis (http://www.lix.polytechnique.fr/~kostas/) <kostas@chatzi.org>",
   "contributors": ["Marco Stronati (http://stronati.org) <marco@stronati.org>"],


### PR DESCRIPTION
This commit makes it possible to use Mozilla's new Jetpack Mechanics
tool to build, test, and deploy the add-on. The changes are minimal,
following the advice in
https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/cfx_to_jpm
and are backwards-compatible with `cfx` use, so both tools can be used.